### PR TITLE
Add comparastore as a company that uses Turbo

### DIFF
--- a/docs/components/clients/users.ts
+++ b/docs/components/clients/users.ts
@@ -526,4 +526,13 @@ export const users: Array<TurboUser> = [
       width: 150,
     },
   },
+  {
+    caption: "Comparastore",
+    image: "/images/logos/comparastore.svg",
+    infoLink: "https://www.comparastore.com",
+    pinned: true,
+    style: {
+      width: 175
+    },
+  }
 ];


### PR DESCRIPTION
Very grateful for the work of the developers behind this incredible tool that is Turbo. As the company that implemented Turborepo and very soon Turbopack, we would be honoured to have our logo on the page.